### PR TITLE
Add BlogException as custom base exception for domain related exceptions

### DIFF
--- a/src/Blogger.APIs/Blogger.APIs.csproj
+++ b/src/Blogger.APIs/Blogger.APIs.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
+    <UserSecretsId>ba328c9e-6323-4c3e-9432-e3a32d9b4f97</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Blogger.APIs/ErrorHandling/GlobalExceptionHandler.cs
+++ b/src/Blogger.APIs/ErrorHandling/GlobalExceptionHandler.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 using Microsoft.AspNetCore.Diagnostics;
 
 namespace Blogger.APIs.ErrorHandling;

--- a/src/Blogger.Application/Articles/CreateArticle/ArticleAlreadyExistsException.cs
+++ b/src/Blogger.Application/Articles/CreateArticle/ArticleAlreadyExistsException.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Application.Articles.CreateArticle;
 

--- a/src/Blogger.Application/Articles/CreateArticle/ArticleAlreadyExistsException.cs
+++ b/src/Blogger.Application/Articles/CreateArticle/ArticleAlreadyExistsException.cs
@@ -1,6 +1,8 @@
-﻿namespace Blogger.Application.Articles.CreateArticle;
+﻿using Blogger.Domain.Common;
 
-public sealed class ArticleAlreadyExistsException : Exception
+namespace Blogger.Application.Articles.CreateArticle;
+
+public sealed class ArticleAlreadyExistsException : BlogException
 {
     private const string _messages = "Article with Title `{0}` already exists.";
     public ArticleAlreadyExistsException(string articleId)

--- a/src/Blogger.Application/Articles/MakeDraft/DraftAlreadyExistsException.cs
+++ b/src/Blogger.Application/Articles/MakeDraft/DraftAlreadyExistsException.cs
@@ -1,6 +1,8 @@
-﻿namespace Blogger.Application.Articles.MakeDraft;
+﻿using Blogger.Domain.Common;
 
-public sealed class DraftAlreadyExistsException : Exception
+namespace Blogger.Application.Articles.MakeDraft;
+
+public sealed class DraftAlreadyExistsException : BlogException
 {
     private const string _messages = "Draft with Title `{0}` already exists.";
     public DraftAlreadyExistsException(string articleId)

--- a/src/Blogger.Application/Articles/MakeDraft/DraftAlreadyExistsException.cs
+++ b/src/Blogger.Application/Articles/MakeDraft/DraftAlreadyExistsException.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Application.Articles.MakeDraft;
 

--- a/src/Blogger.Application/Articles/UpdateDraft/DraftNotFoundException.cs
+++ b/src/Blogger.Application/Articles/UpdateDraft/DraftNotFoundException.cs
@@ -1,5 +1,7 @@
-﻿namespace Blogger.Application.Articles.UpdateDraft;
-public class DraftNotFoundException : Exception
+﻿using Blogger.Domain.Common;
+
+namespace Blogger.Application.Articles.UpdateDraft;
+public class DraftNotFoundException : BlogException
 {
     private const string _message = "Draft not found.";
 

--- a/src/Blogger.Application/Articles/UpdateDraft/DraftNotFoundException.cs
+++ b/src/Blogger.Application/Articles/UpdateDraft/DraftNotFoundException.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Application.Articles.UpdateDraft;
 public class DraftNotFoundException : BlogException

--- a/src/Blogger.Application/Articles/UpdateDraft/DraftTitleDuplicatedException.cs
+++ b/src/Blogger.Application/Articles/UpdateDraft/DraftTitleDuplicatedException.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Application.Articles.UpdateDraft;
 public class DraftTitleDuplicatedException : BlogException

--- a/src/Blogger.Application/Articles/UpdateDraft/DraftTitleDuplicatedException.cs
+++ b/src/Blogger.Application/Articles/UpdateDraft/DraftTitleDuplicatedException.cs
@@ -1,5 +1,7 @@
-﻿namespace Blogger.Application.Articles.UpdateDraft;
-public class DraftTitleDuplicatedException : Exception
+﻿using Blogger.Domain.Common;
+
+namespace Blogger.Application.Articles.UpdateDraft;
+public class DraftTitleDuplicatedException : BlogException
 {
     private const string _message = "A draft with the same title already exists. Draft title: {0}";
 

--- a/src/Blogger.Application/Comments/ApproveComment/InvalidCommentApprovalLinkException.cs
+++ b/src/Blogger.Application/Comments/ApproveComment/InvalidCommentApprovalLinkException.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Application.Comments.ApproveComment;
 

--- a/src/Blogger.Application/Comments/ApproveComment/InvalidCommentApprovalLinkException.cs
+++ b/src/Blogger.Application/Comments/ApproveComment/InvalidCommentApprovalLinkException.cs
@@ -1,6 +1,8 @@
-﻿namespace Blogger.Application.Comments.ApproveComment;
+﻿using Blogger.Domain.Common;
 
-public class InvalidCommentApprovalLinkException : Exception
+namespace Blogger.Application.Comments.ApproveComment;
+
+public class InvalidCommentApprovalLinkException : BlogException
 {
     private const string _message = "Invalid comment approved link.";
     public InvalidCommentApprovalLinkException() : base(_message)

--- a/src/Blogger.Application/Comments/ApproveReplay/CommentNotFoundException.cs
+++ b/src/Blogger.Application/Comments/ApproveReplay/CommentNotFoundException.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Application.Comments.ApproveReplay;
 public class CommentNotFoundException : BlogException

--- a/src/Blogger.Application/Comments/ApproveReplay/CommentNotFoundException.cs
+++ b/src/Blogger.Application/Comments/ApproveReplay/CommentNotFoundException.cs
@@ -1,5 +1,7 @@
-﻿namespace Blogger.Application.Comments.ApproveReplay;
-public class CommentNotFoundException : Exception
+﻿using Blogger.Domain.Common;
+
+namespace Blogger.Application.Comments.ApproveReplay;
+public class CommentNotFoundException : BlogException
 {
     private const string _message = "Comment not found.";
 

--- a/src/Blogger.Application/Comments/MakeComment/NotFoundArticleException.cs
+++ b/src/Blogger.Application/Comments/MakeComment/NotFoundArticleException.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Application.Comments.MakeComment;
 public class NotFoundArticleException : BlogException

--- a/src/Blogger.Application/Comments/MakeComment/NotFoundArticleException.cs
+++ b/src/Blogger.Application/Comments/MakeComment/NotFoundArticleException.cs
@@ -1,5 +1,7 @@
-﻿namespace Blogger.Application.Comments.MakeComment;
-public class NotFoundArticleException : Exception
+﻿using Blogger.Domain.Common;
+
+namespace Blogger.Application.Comments.MakeComment;
+public class NotFoundArticleException : BlogException
 {
     private const string _message = "Article not found.";
 

--- a/src/Blogger.Application/Comments/MakeComment/NotValidClientException.cs
+++ b/src/Blogger.Application/Comments/MakeComment/NotValidClientException.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Application.Comments.MakeComment;
 

--- a/src/Blogger.Application/Comments/MakeComment/NotValidClientException.cs
+++ b/src/Blogger.Application/Comments/MakeComment/NotValidClientException.cs
@@ -1,6 +1,8 @@
-﻿namespace Blogger.Application.Comments.MakeComment;
+﻿using Blogger.Domain.Common;
 
-public class NotValidClientException : Exception
+namespace Blogger.Application.Comments.MakeComment;
+
+public class NotValidClientException : BlogException
 {
     private const string _messages = "Invalid client id.";
 

--- a/src/Blogger.Application/Comments/ReplayToComment/NotFoundArticleException.cs
+++ b/src/Blogger.Application/Comments/ReplayToComment/NotFoundArticleException.cs
@@ -1,5 +1,7 @@
-﻿namespace Blogger.Application.Comments.ReplayToComment;
-public class NotFoundCommentException : Exception
+﻿using Blogger.Domain.Common;
+
+namespace Blogger.Application.Comments.ReplayToComment;
+public class NotFoundCommentException : BlogException
 {
     private const string _message = "Invalid comment for replay!";
 

--- a/src/Blogger.Application/Comments/ReplayToComment/NotFoundArticleException.cs
+++ b/src/Blogger.Application/Comments/ReplayToComment/NotFoundArticleException.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Application.Comments.ReplayToComment;
 public class NotFoundCommentException : BlogException

--- a/src/Blogger.Application/Subscribers/Subscribe/DuplicateSubscribtionException.cs
+++ b/src/Blogger.Application/Subscribers/Subscribe/DuplicateSubscribtionException.cs
@@ -1,6 +1,8 @@
-﻿namespace Blogger.Application.Subscribers.Subscribe;
+﻿using Blogger.Domain.Common;
 
-public class DuplicateSubscribtionException : Exception
+namespace Blogger.Application.Subscribers.Subscribe;
+
+public class DuplicateSubscribtionException : BlogException
 {
     private const string _messages = "Duplicated registration!";
 

--- a/src/Blogger.Application/Subscribers/Subscribe/DuplicateSubscribtionException.cs
+++ b/src/Blogger.Application/Subscribers/Subscribe/DuplicateSubscribtionException.cs
@@ -1,4 +1,4 @@
-﻿using Blogger.Domain.Common;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Application.Subscribers.Subscribe;
 

--- a/src/Blogger.Domain/ArticleAggregate/DraftTagsMissingException.cs
+++ b/src/Blogger.Domain/ArticleAggregate/DraftTagsMissingException.cs
@@ -1,4 +1,6 @@
-﻿namespace Blogger.Domain.ArticleAggregate;
+﻿using Blogger.Domain.Common.Exceptions;
+
+namespace Blogger.Domain.ArticleAggregate;
 public class DraftTagsMissingException : BlogException
 {
     private const string _messages = "Cannot publish draft without tags.";

--- a/src/Blogger.Domain/ArticleAggregate/DraftTagsMissingException.cs
+++ b/src/Blogger.Domain/ArticleAggregate/DraftTagsMissingException.cs
@@ -1,5 +1,5 @@
 ﻿namespace Blogger.Domain.ArticleAggregate;
-public class DraftTagsMissingException : Exception
+public class DraftTagsMissingException : BlogException
 {
     private const string _messages = "Cannot publish draft without tags.";
     public DraftTagsMissingException() : base(_messages)

--- a/src/Blogger.Domain/ArticleAggregate/InvalidArticleActionException.cs
+++ b/src/Blogger.Domain/ArticleAggregate/InvalidArticleActionException.cs
@@ -1,6 +1,6 @@
 ﻿namespace Blogger.Domain.ArticleAggregate;
 
-public class InvalidArticleActionException : Exception
+public class InvalidArticleActionException : BlogException
 {
     public InvalidArticleActionException(ArticleStatus status)
         : base(string.Format("Invalid action on {0} status", status))

--- a/src/Blogger.Domain/ArticleAggregate/InvalidArticleActionException.cs
+++ b/src/Blogger.Domain/ArticleAggregate/InvalidArticleActionException.cs
@@ -1,4 +1,6 @@
-﻿namespace Blogger.Domain.ArticleAggregate;
+﻿using Blogger.Domain.Common.Exceptions;
+
+namespace Blogger.Domain.ArticleAggregate;
 
 public class InvalidArticleActionException : BlogException
 {

--- a/src/Blogger.Domain/ArticleAggregate/InvalidReplayApprovalLinkException.cs
+++ b/src/Blogger.Domain/ArticleAggregate/InvalidReplayApprovalLinkException.cs
@@ -1,6 +1,6 @@
 ﻿namespace Blogger.Domain.ArticleAggregate;
 
-public class InvalidReplayApprovalLinkException : Exception
+public class InvalidReplayApprovalLinkException : BlogException
 {
     private const string _message = "Invalid replay approved link.";
     public InvalidReplayApprovalLinkException() : base(_message)

--- a/src/Blogger.Domain/ArticleAggregate/InvalidReplayApprovalLinkException.cs
+++ b/src/Blogger.Domain/ArticleAggregate/InvalidReplayApprovalLinkException.cs
@@ -1,4 +1,6 @@
-﻿namespace Blogger.Domain.ArticleAggregate;
+﻿using Blogger.Domain.Common.Exceptions;
+
+namespace Blogger.Domain.ArticleAggregate;
 
 public class InvalidReplayApprovalLinkException : BlogException
 {

--- a/src/Blogger.Domain/CommentAggregate/Client.cs
+++ b/src/Blogger.Domain/CommentAggregate/Client.cs
@@ -1,4 +1,6 @@
-﻿namespace Blogger.Domain.CommentAggregate;
+﻿using Blogger.Domain.Common.Exceptions;
+
+namespace Blogger.Domain.CommentAggregate;
 
 public class Client : ValueObject<Client>
 {
@@ -10,18 +12,19 @@ public class Client : ValueObject<Client>
     {
         yield return FullName;
         yield return Email;
-    } 
+    }
 
     public static Client Create(string fullName, string email)
     {
         if (MailAddress.TryCreate(email, out _))
         {
-            return new Client { 
+            return new Client
+            {
                 Email = email,
                 FullName = fullName,
             };
         }
 
-        throw new ArgumentException("Invalid email address");
+        throw new InvalidEmailAddressException();
     }
 }

--- a/src/Blogger.Domain/CommentAggregate/UnapprovedCommentException.cs
+++ b/src/Blogger.Domain/CommentAggregate/UnapprovedCommentException.cs
@@ -1,6 +1,6 @@
 ﻿namespace Blogger.Domain.CommentAggregate;
 
-public class UnapprovedCommentException : Exception
+public class UnapprovedCommentException : BlogException
 {
     private const string _messages = "Replay is not allowed for unapproved comments.";
     public UnapprovedCommentException() : base(_messages)

--- a/src/Blogger.Domain/CommentAggregate/UnapprovedCommentException.cs
+++ b/src/Blogger.Domain/CommentAggregate/UnapprovedCommentException.cs
@@ -1,4 +1,6 @@
-﻿namespace Blogger.Domain.CommentAggregate;
+﻿using Blogger.Domain.Common.Exceptions;
+
+namespace Blogger.Domain.CommentAggregate;
 
 public class UnapprovedCommentException : BlogException
 {

--- a/src/Blogger.Domain/Common/BlogException.cs
+++ b/src/Blogger.Domain/Common/BlogException.cs
@@ -1,0 +1,6 @@
+﻿namespace Blogger.Domain.Common;
+
+public abstract class BlogException : Exception
+{
+    protected BlogException(string? message) : base(message) { }
+}

--- a/src/Blogger.Domain/Common/Exceptions/BlogException.cs
+++ b/src/Blogger.Domain/Common/Exceptions/BlogException.cs
@@ -1,6 +1,8 @@
-﻿namespace Blogger.Domain.Common;
+﻿namespace Blogger.Domain.Common.Exceptions;
 
 public abstract class BlogException : Exception
 {
+    protected BlogException() : base() { }
+
     protected BlogException(string? message) : base(message) { }
 }

--- a/src/Blogger.Domain/Common/Exceptions/InvalidEmailAddressException.cs
+++ b/src/Blogger.Domain/Common/Exceptions/InvalidEmailAddressException.cs
@@ -1,0 +1,8 @@
+﻿namespace Blogger.Domain.Common.Exceptions;
+
+public class InvalidEmailAddressException : BlogException
+{
+    private const string _messages = "Invalid Email Address";
+
+    public InvalidEmailAddressException() : base(_messages) { }
+}

--- a/src/Blogger.Domain/SubscriberAggregate/SubscriberId.cs
+++ b/src/Blogger.Domain/SubscriberAggregate/SubscriberId.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Mail;
+using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Domain.SubscriberAggregate;
 
@@ -10,17 +11,17 @@ public class SubscriberId : ValueObject<SubscriberId>
     {
         yield return Email;
     }
-  
+
     public static SubscriberId CreateUniqueId(string email)
     {
-        if(MailAddress.TryCreate(email, out _)) 
+        if (MailAddress.TryCreate(email, out _))
         {
             return new SubscriberId { Email = email };
         }
 
-        throw new ArgumentException("Invalid email address");
+        throw new InvalidEmailAddressException();
     }
 
     public static SubscriberId Create(string value) =>
-        new SubscriberId{ Email = value };
+        new SubscriberId { Email = value };
 }


### PR DESCRIPTION
Currently, The API presentation layer gives 500 Http Status Code to the client in case of any domain related exception.
I have added a base class for domain and application layer related exceptions named "BlogException" and each custom exception in application like "UnapprovedCommentException" must inherited from "BlogException".
In GlobalExceptionHandler I check the type of exception and in case of BlogExceptions the application returns 400 status code to the client.