### PR TITLE
Enable TreatWarningsAsError to keep code quality

### DIFF
--- a/src/Blogger.APIs/Blogger.APIs.csproj
+++ b/src/Blogger.APIs/Blogger.APIs.csproj
@@ -1,32 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <DockerfileContext>..\..</DockerfileContext>
-    <UserSecretsId>ba328c9e-6323-4c3e-9432-e3a32d9b4f97</UserSecretsId>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+		<DockerfileContext>..\..</DockerfileContext>
+		<UserSecretsId>ba328c9e-6323-4c3e-9432-e3a32d9b4f97</UserSecretsId>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="Controllers\**" />
-    <Content Remove="Controllers\**" />
-    <EmbeddedResource Remove="Controllers\**" />
-    <None Remove="Controllers\**" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="Controllers\**" />
+		<Content Remove="Controllers\**" />
+		<EmbeddedResource Remove="Controllers\**" />
+		<None Remove="Controllers\**" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
-    <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
-	  <PackageReference Include="Mapster" Version="7.4.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
+		<PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
+		<PackageReference Include="Mapster" Version="7.4.0" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Blogger.Application\Blogger.Application.csproj" />
-    <ProjectReference Include="..\Blogger.Infrastructure\Blogger.Infrastructure.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Blogger.Application\Blogger.Application.csproj" />
+		<ProjectReference Include="..\Blogger.Infrastructure\Blogger.Infrastructure.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Blogger.Application/Blogger.Application.csproj
+++ b/src/Blogger.Application/Blogger.Application.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Blogger.Domain\Blogger.Domain.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Blogger.Domain\Blogger.Domain.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MediatR" Version="12.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="MediatR" Version="12.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+	</ItemGroup>
 
 </Project>

--- a/src/Blogger.Domain/ArticleAggregate/Article.cs
+++ b/src/Blogger.Domain/ArticleAggregate/Article.cs
@@ -5,13 +5,13 @@ namespace Blogger.Domain.ArticleAggregate;
 public class Article : AggregateRootBase<ArticleId>
 {
 
-    public Article(ArticleId slug):base(slug)
-    {  
+    public Article(ArticleId slug) : base(slug)
+    {
         _tags = [];
         _commentIds = [];
     }
 
-    private Article()  : this(null) { }
+    private Article() : this(null!) { }
 
 
     private IList<CommentId> _commentIds = null!;

--- a/src/Blogger.Domain/ArticleAggregate/Tag.cs
+++ b/src/Blogger.Domain/ArticleAggregate/Tag.cs
@@ -3,8 +3,8 @@
 namespace Blogger.Domain.ArticleAggregate;
 public class Tag : ValueObject<Tag>
 {
-    public string Value { get; init; }
-     
+    public string Value { get; init; } = null!;
+
     public override IEnumerable<object> GetEqualityComponenets()
     {
         yield return Value;
@@ -12,7 +12,8 @@ public class Tag : ValueObject<Tag>
 
     public static Tag Create(string tagValue)
     {
-        return new Tag { 
+        return new Tag
+        {
             Value = tagValue.Kebaberize()
         };
     }

--- a/src/Blogger.Domain/Blogger.Domain.csproj
+++ b/src/Blogger.Domain/Blogger.Domain.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Humanizer.Core" Version="2.14.1" />
+	</ItemGroup>
 
 </Project>

--- a/src/Blogger.Domain/CommentAggregate/Comment.cs
+++ b/src/Blogger.Domain/CommentAggregate/Comment.cs
@@ -2,20 +2,21 @@
 
 namespace Blogger.Domain.CommentAggregate;
 
-public class Comment: AggregateRootBase<CommentId>
+public class Comment : AggregateRootBase<CommentId>
 {
-
-    public Comment(CommentId id):base(id)
+    private IList<Reply> _replies;
+    public Comment(CommentId id) : base(id)
     {
         _replies = [];
     }
-    public Comment() : base(null)
+
+    public Comment() : this(null!)
     {
     }
 
     public Client Client { get; init; } = null!;
     public ApproveLink ApproveLink { get; init; } = null!;
-    public ArticleId ArticleId{ get; init; } = null!;
+    public ArticleId ArticleId { get; init; } = null!;
 
     public DateTime CreatedOnUtc { get; init; }
 
@@ -23,10 +24,10 @@ public class Comment: AggregateRootBase<CommentId>
 
     public bool IsApproved { get; private set; }
 
-    private IList<Reply> _replies;
+
     public IReadOnlyCollection<Reply> Replies => _replies.ToImmutableList();
 
-    public static Comment Create(ArticleId articleId,  Client client, string content, ApproveLink approveLink) =>
+    public static Comment Create(ArticleId articleId, Client client, string content, ApproveLink approveLink) =>
         new Comment(CommentId.CreateUniqueId())
         {
             ArticleId = articleId,
@@ -39,7 +40,7 @@ public class Comment: AggregateRootBase<CommentId>
 
     public void Approve() => IsApproved = true;
 
-    public Reply ReplyComment(Client client,string content, ApproveLink approveLink)
+    public Reply ReplyComment(Client client, string content, ApproveLink approveLink)
     {
         if (!IsApproved)
         {

--- a/src/Blogger.Domain/CommentAggregate/Replay.cs
+++ b/src/Blogger.Domain/CommentAggregate/Replay.cs
@@ -2,9 +2,9 @@
 
 public class Replay(ReplayId id) : EntityBase<ReplayId>(id)
 {
-    public Replay() : this(null)
+    public Replay() : this(null!)
     {
-        
+
     }
 
     public Client Client { get; init; } = null!;

--- a/src/Blogger.Domain/CommentAggregate/Reply.cs
+++ b/src/Blogger.Domain/CommentAggregate/Reply.cs
@@ -2,9 +2,9 @@
 
 public class Reply(ReplyId id) : EntityBase<ReplyId>(id)
 {
-    public Reply() : this(null)
+    public Reply() : this(null!)
     {
-        
+
     }
 
     public Client Client { get; init; } = null!;

--- a/src/Blogger.Domain/SubscriberAggregate/ISubscriberRepository.cs
+++ b/src/Blogger.Domain/SubscriberAggregate/ISubscriberRepository.cs
@@ -4,7 +4,7 @@ namespace Blogger.Domain.SubscriberAggregate;
 public interface ISubscriberRepository
 {
     Task CreateAsync(Subscriber subscriber, CancellationToken cancellationToken);
-    Task<Subscriber> FindById(SubscriberId subscriberId);
+    Task<Subscriber?> FindById(SubscriberId subscriberId);
     Task<bool> IsExists(SubscriberId subscriberId, CancellationToken cancellationToken);
     Task SavaChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/Blogger.Domain/SubscriberAggregate/SubscriberId.cs
+++ b/src/Blogger.Domain/SubscriberAggregate/SubscriberId.cs
@@ -1,11 +1,10 @@
-﻿using System.Net.Mail;
-using Blogger.Domain.Common.Exceptions;
+﻿using Blogger.Domain.Common.Exceptions;
 
 namespace Blogger.Domain.SubscriberAggregate;
 
 public class SubscriberId : ValueObject<SubscriberId>
 {
-    public string Email { get; set; }
+    public string Email { get; set; } = null!;
 
     public override IEnumerable<object> GetEqualityComponenets()
     {

--- a/src/Blogger.Infrastructure/Blogger.Infrastructure.csproj
+++ b/src/Blogger.Infrastructure/Blogger.Infrastructure.csproj
@@ -1,27 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Blogger.Application\Blogger.Application.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Blogger.Application\Blogger.Application.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Blogger.Infrastructure/Persistence/Repositories/SubscriberRepository.cs
+++ b/src/Blogger.Infrastructure/Persistence/Repositories/SubscriberRepository.cs
@@ -1,6 +1,4 @@
-﻿using Blogger.Domain.SubscriberAggregate;
-
-namespace Blogger.Infrastructure.Persistence.Repositories;
+﻿namespace Blogger.Infrastructure.Persistence.Repositories;
 internal class SubscriberRepository(BloggerDbContext bloggerDbContext) : ISubscriberRepository
 {
 
@@ -9,14 +7,14 @@ internal class SubscriberRepository(BloggerDbContext bloggerDbContext) : ISubscr
         await bloggerDbContext.Subscribers.AddAsync(subscriber, cancellationToken);
     }
 
-    public async Task<Subscriber> FindById(SubscriberId subscriberId)
+    public async Task<Subscriber?> FindById(SubscriberId subscriberId)
     {
         var subscriber = await bloggerDbContext.Subscribers.FindAsync(subscriberId);
         return subscriber;
     }
     public Task<bool> IsExists(SubscriberId subscriberId, CancellationToken cancellationToken)
     {
-        return bloggerDbContext.Subscribers.AnyAsync(s=>s.Id.Equals(subscriberId), cancellationToken);
+        return bloggerDbContext.Subscribers.AnyAsync(s => s.Id.Equals(subscriberId), cancellationToken);
     }
     public async Task SavaChangesAsync(CancellationToken cancellationToken)
     {

--- a/tests/Blogger.ArchitectureTests/Blogger.ArchitectureTests.csproj
+++ b/tests/Blogger.ArchitectureTests/Blogger.ArchitectureTests.csproj
@@ -1,37 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+		<PackageReference Include="xunit" Version="2.7.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Blogger.APIs\Blogger.APIs.csproj" />
+		<ProjectReference Include="..\..\src\Blogger.Application\Blogger.Application.csproj" />
+		<ProjectReference Include="..\..\src\Blogger.Domain\Blogger.Domain.csproj" />
+		<ProjectReference Include="..\..\src\Blogger.Infrastructure\Blogger.Infrastructure.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Blogger.APIs\Blogger.APIs.csproj" />
-    <ProjectReference Include="..\..\src\Blogger.Application\Blogger.Application.csproj" />
-    <ProjectReference Include="..\..\src\Blogger.Domain\Blogger.Domain.csproj" />
-    <ProjectReference Include="..\..\src\Blogger.Infrastructure\Blogger.Infrastructure.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
-  </ItemGroup>
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
 
 </Project>

--- a/tests/Blogger.FunctionalTests/Blogger.FunctionalTests.csproj
+++ b/tests/Blogger.FunctionalTests/Blogger.FunctionalTests.csproj
@@ -1,37 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+		<PackageReference Include="xunit" Version="2.7.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Blogger.APIs\Blogger.APIs.csproj" />
+		<ProjectReference Include="..\..\src\Blogger.Application\Blogger.Application.csproj" />
+		<ProjectReference Include="..\..\src\Blogger.Domain\Blogger.Domain.csproj" />
+		<ProjectReference Include="..\..\src\Blogger.Infrastructure\Blogger.Infrastructure.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Blogger.APIs\Blogger.APIs.csproj" />
-    <ProjectReference Include="..\..\src\Blogger.Application\Blogger.Application.csproj" />
-    <ProjectReference Include="..\..\src\Blogger.Domain\Blogger.Domain.csproj" />
-    <ProjectReference Include="..\..\src\Blogger.Infrastructure\Blogger.Infrastructure.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
-  </ItemGroup>
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
 
 </Project>

--- a/tests/Blogger.IntegrationTests/Blogger.IntegrationTests.csproj
+++ b/tests/Blogger.IntegrationTests/Blogger.IntegrationTests.csproj
@@ -1,23 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="xunit" Version="2.5.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
-  </ItemGroup>
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
 
 </Project>

--- a/tests/Blogger.UnitTests/Blogger.UnitTests.csproj
+++ b/tests/Blogger.UnitTests/Blogger.UnitTests.csproj
@@ -1,38 +1,38 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+		<PackageReference Include="Moq" Version="4.20.70" />
+		<PackageReference Include="xunit" Version="2.7.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Blogger.APIs\Blogger.APIs.csproj" />
+		<ProjectReference Include="..\..\src\Blogger.Application\Blogger.Application.csproj" />
+		<ProjectReference Include="..\..\src\Blogger.Domain\Blogger.Domain.csproj" />
+		<ProjectReference Include="..\..\src\Blogger.Infrastructure\Blogger.Infrastructure.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Blogger.APIs\Blogger.APIs.csproj" />
-    <ProjectReference Include="..\..\src\Blogger.Application\Blogger.Application.csproj" />
-    <ProjectReference Include="..\..\src\Blogger.Domain\Blogger.Domain.csproj" />
-    <ProjectReference Include="..\..\src\Blogger.Infrastructure\Blogger.Infrastructure.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
-  </ItemGroup>
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
TreatWarningsAsError is added to all projects. it's a good practice to have warnings that may be a potential error.