### PR TITLE
Bugfix: Negate MakeCommentCommandHandler Condition

### DIFF
--- a/src/Blogger.Application/Comments/MakeComment/MakeCommentCommandHandler.cs
+++ b/src/Blogger.Application/Comments/MakeComment/MakeCommentCommandHandler.cs
@@ -16,8 +16,7 @@ public class MakeCommentCommandHandler(
 
     public async Task<MakeCommentCommandResponse> Handle(MakeCommentCommand request, CancellationToken cancellationToken)
     {
-
-        if (await _articleService.IsArticleIdValidAsync(request.ArticleId, cancellationToken))
+        if (!await _articleService.IsArticleIdValidAsync(request.ArticleId, cancellationToken))
         {
             throw new NotFoundArticleException();
         }


### PR DESCRIPTION
`MakeCommentCommandHandler` will always throw a `NotFoundArticleException` exception if article id **is valid**