### PR TITLE
Fix typos

### DIFF
--- a/tests/Blogger.UnitTests/BuldingBlocks/Domain/AggregateRootBaseTests.cs
+++ b/tests/Blogger.UnitTests/BuldingBlocks/Domain/AggregateRootBaseTests.cs
@@ -7,13 +7,13 @@ public class AggregateRootBaseTests
     [Fact]
     public void events_should_be_have_item_when_adding_event()
     {
-        // arrane
+        // arrange
         var aggregateRoot = new ConcreteAggregateRoot(10);
 
         // act
         aggregateRoot.RaiseCreatedEvent();
 
-        //
+        // assert
         aggregateRoot.Events.Should().NotBeEmpty();
         aggregateRoot.Events.Should().HaveCount(1);
     }
@@ -21,7 +21,7 @@ public class AggregateRootBaseTests
    [Fact]
     public void events_should_be_empty_when_create_new_aggregate()
     {
-        // arrane
+        // arrange
         var aggregateRoot = new ConcreteAggregateRoot(10);
   
         // act
@@ -31,7 +31,7 @@ public class AggregateRootBaseTests
     [Fact]
     public void events_should_be_empty_when_call_CleanEvents()
     {
-        // arrane
+        // arrange
         var aggregateRoot = new ConcreteAggregateRoot(10);
         
         // act

--- a/tests/Blogger.UnitTests/BuldingBlocks/Domain/ValueObjectTests.cs
+++ b/tests/Blogger.UnitTests/BuldingBlocks/Domain/ValueObjectTests.cs
@@ -61,7 +61,7 @@ public class ValueObjectTests
     }
 
     [Fact]
-    public void value_objects_of_same_type_should_be_not_equal_when_values_diffrent()
+    public void value_objects_of_same_type_should_not_be_equal_when_values_are_different()
     {
         // arrange
         var valueObjectA = new Address

--- a/tests/Blogger.UnitTests/Domain/ArticleTests.cs
+++ b/tests/Blogger.UnitTests/Domain/ArticleTests.cs
@@ -39,7 +39,7 @@ public class ArticleTests
     }
 
     [Fact]
-    public void Publish_ShouldBeThrowDraftTagsMissingException_WhenHaventTagns()
+    public void Publish_ShouldThrowDraftTagsMissingException_WhenDoesntHaveTags()
     {
         // arrange
         var draft = Article.CreateArticle("hi bye", "nothing", "for what");


### PR DESCRIPTION
**Title:** Fix typos in UnitTests

**Summary:**
This pull request aims to enhance the reliability of the codebase.

**Changes Made:**

1. **ConcreteAggregateRoot Tests:**
   - AAA pattern correctly applied.

2. **ValueObjectTests:**
   - Renamed the test from  `value_objects_of_same_type_should_be_not_equal_when_values_diffrent` to `value_objects_of_same_type_should_not_be_equal_when_values_are_different`.

3. **ArticleTests:**
   - Renamed the test from`Publish_ShouldBeThrowDraftTagsMissingException_WhenHaventTagns` to `Publish_ShouldThrowDraftTagsMissingException_WhenDoesntHaveTags`

**Request for Review:**

Your feedback on these changes is highly appreciated. Please review and merge as appropriate. Thank you🌷

