### PR TITLE
Fix typo in ValueObject class for GetEqualityComponents abstract method

### DIFF
--- a/src/Blogger.Domain/ArticleAggregate/ArticleId.cs
+++ b/src/Blogger.Domain/ArticleAggregate/ArticleId.cs
@@ -6,7 +6,7 @@ public sealed class ArticleId : ValueObject<ArticleId>
 {
     public required string Slug { get; init; }
 
-    public override IEnumerable<object> GetEqualityComponenets()
+    public override IEnumerable<object> GetEqualityComponents()
     {
         yield return Slug;
     }

--- a/src/Blogger.Domain/ArticleAggregate/Author.cs
+++ b/src/Blogger.Domain/ArticleAggregate/Author.cs
@@ -14,7 +14,7 @@ public class Author : ValueObject<Author>
         JobTitle = jobTitle;
     }
 
-    public override IEnumerable<object> GetEqualityComponenets()
+    public override IEnumerable<object> GetEqualityComponents()
     {
         yield return FullName;
         yield return Avatar;

--- a/src/Blogger.Domain/ArticleAggregate/Tag.cs
+++ b/src/Blogger.Domain/ArticleAggregate/Tag.cs
@@ -5,7 +5,7 @@ public class Tag : ValueObject<Tag>
 {
     public string Value { get; init; } = null!;
 
-    public override IEnumerable<object> GetEqualityComponenets()
+    public override IEnumerable<object> GetEqualityComponents()
     {
         yield return Value;
     }

--- a/src/Blogger.Domain/CommentAggregate/ApproveLink.cs
+++ b/src/Blogger.Domain/CommentAggregate/ApproveLink.cs
@@ -6,7 +6,7 @@ public class ApproveLink : ValueObject<Client>
 
     public DateTime ExpirationOnUtc { get; set; }
 
-    public override IEnumerable<object> GetEqualityComponenets()
+    public override IEnumerable<object> GetEqualityComponents()
     {
         yield return ApproveId;
         yield return ExpirationOnUtc;

--- a/src/Blogger.Domain/CommentAggregate/Client.cs
+++ b/src/Blogger.Domain/CommentAggregate/Client.cs
@@ -8,7 +8,7 @@ public class Client : ValueObject<Client>
 
     public string Email { get; set; } = null!;
 
-    public override IEnumerable<object> GetEqualityComponenets()
+    public override IEnumerable<object> GetEqualityComponents()
     {
         yield return FullName;
         yield return Email;

--- a/src/Blogger.Domain/CommentAggregate/CommentId.cs
+++ b/src/Blogger.Domain/CommentAggregate/CommentId.cs
@@ -4,7 +4,7 @@ public class CommentId : ValueObject<CommentId>
 {
     public Guid Value { get; init; }
 
-    public override IEnumerable<object> GetEqualityComponenets()
+    public override IEnumerable<object> GetEqualityComponents()
     {
         yield return Value;
     }

--- a/src/Blogger.Domain/CommentAggregate/ReplyId.cs
+++ b/src/Blogger.Domain/CommentAggregate/ReplyId.cs
@@ -4,7 +4,7 @@ public class ReplyId : ValueObject<ReplyId>
 {
     public Guid Value { get; init; }
 
-    public override IEnumerable<object> GetEqualityComponenets()
+    public override IEnumerable<object> GetEqualityComponents()
     {
         yield return Value;
     }

--- a/src/Blogger.Domain/Common/ValueObject.cs
+++ b/src/Blogger.Domain/Common/ValueObject.cs
@@ -2,13 +2,13 @@
 
 public abstract class ValueObject<T> where T : ValueObject<T>
 {
-    public abstract IEnumerable<object> GetEqualityComponenets();
+    public abstract IEnumerable<object> GetEqualityComponents();
 
     public override bool Equals(object? obj) 
         => obj is not null &&
            obj is T valueObject &&
            obj.GetType() == GetType() &&
-           GetEqualityComponenets().SequenceEqual(valueObject.GetEqualityComponenets());
+           GetEqualityComponents().SequenceEqual(valueObject.GetEqualityComponents());
 
     public static bool operator ==(ValueObject<T> left, ValueObject<T> right)
         => left.Equals(right);
@@ -17,7 +17,7 @@ public abstract class ValueObject<T> where T : ValueObject<T>
         => !left.Equals(right);
 
     public override int GetHashCode()
-        => GetEqualityComponenets()
+        => GetEqualityComponents()
                 .Select(x => x?.GetHashCode() ?? 0)
                 .Aggregate((x, y) => x ^ y);
 }

--- a/src/Blogger.Domain/SubscriberAggregate/SubscriberId.cs
+++ b/src/Blogger.Domain/SubscriberAggregate/SubscriberId.cs
@@ -6,7 +6,7 @@ public class SubscriberId : ValueObject<SubscriberId>
 {
     public MailAddress Email { get; init; } = null!;
 
-    public override IEnumerable<object> GetEqualityComponenets()
+    public override IEnumerable<object> GetEqualityComponents()
     {
         yield return Email;
     }

--- a/tests/Blogger.UnitTests/BuldingBlocks/Domain/ValueObjectTests.cs
+++ b/tests/Blogger.UnitTests/BuldingBlocks/Domain/ValueObjectTests.cs
@@ -94,7 +94,7 @@ public class ValueObjectTests
         public required string State { get; init; }
         public required string PostalCode { get; init; }
 
-        public override IEnumerable<object> GetEqualityComponenets()
+        public override IEnumerable<object> GetEqualityComponents()
         {
             yield return City;
             yield return State;
@@ -107,7 +107,7 @@ public class ValueObjectTests
         public required string Corrency { get; init; }
         public required decimal Value { get; init; }
 
-        public override IEnumerable<object> GetEqualityComponenets()
+        public override IEnumerable<object> GetEqualityComponents()
         {
             yield return Corrency;
             yield return Value;


### PR DESCRIPTION
## Fix typo in GetEqualityComponents method signature

In various files throughout the codebase, the method signature for GetEqualityComponents was incorrectly spelled. This commit 
corrects all the typos.