### PR TITLE
Simplify UpdateTags by removing redundant null check

### DIFF
--- a/src/Blogger.Domain/ArticleAggregate/Article.cs
+++ b/src/Blogger.Domain/ArticleAggregate/Article.cs
@@ -86,8 +86,7 @@ public class Article : AggregateRoot<ArticleId>
 
     public void UpdateTags(IReadOnlyList<Tag> tags)
     {
-        if (_tags is not null)
-            _tags.Clear();
+        _tags.Clear();
 
         AddTags(tags);
     }

--- a/src/Blogger.Domain/ArticleAggregate/Tag.cs
+++ b/src/Blogger.Domain/ArticleAggregate/Tag.cs
@@ -20,6 +20,6 @@ public class Tag : ValueObject<Tag>
 
     public override string ToString()
     {
-        return Value.ToString();
+        return Value;
     }
 }


### PR DESCRIPTION
This commit removes the unnecessary null check for _tags in the UpdateTags method.

Since IReadOnlyList<Tag> tags is not nullable, _tags is guaranteed to be initialized before UpdateTags is called. Therefore, the check if (_tags is not null) is redundant and can be safely removed.